### PR TITLE
Fix typo in Runnable Jar section of README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -574,7 +574,7 @@ To run the JAR file, first stop the Liberty instance if it's running. Then, navi
 java -jar guide-getting-started.jar
 ```
 
-When Liberty starts, go to the http://localhost:9080/dev/system/properties[http://localhost:9080/dev/system/properties^] URL to access your application that is now running out of the minimal runnable JAR file.
+When Liberty starts, go to the http://localhost:9080/system/properties[http://localhost:9080/system/properties^] URL to access your application that is now running out of the minimal runnable JAR file.
 
 You can stop the Liberty instance by pressing `CTRL+C` in the command-line session that the instance runs in.
 


### PR DESCRIPTION
I noticed when walking through the getting started guide README, that when showing how to package and test the runnable JAR version, the URL included the `/dev` path. When I tried this out, the URL `http://localhost:9080/dev/system/properties` returned an HTTP 404, but `http://localhost:9080/system/properties` returned the expected response. If this is intended, then it seems this small change to the docs is all that's needed.